### PR TITLE
Updated or removed deprecated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 A facetiously curated list of delightfully amusing Markov chain output, inspired by [memorylessness](https://en.wikipedia.org/wiki/Memorylessness).
 
-If you want to [contribute](https://github.com/sublimino/awesome-funny-markov/blob/master/contributing.md) to this list (please do), send a pull request or contact me [@sublimino](https://twitter.com/sublimino). 
+If you want to [contribute](https://github.com/sublimino/awesome-funny-markov/blob/master/contributing.md) to this list (please do), send a pull request or contact me [@sublimino](https://twitter.com/sublimino).
 
 Looking for more information on Markov Chains? Try [Awesome Machine Learning](https://github.com/josephmisiti/awesome-machine-learning).
-
 
 ## Table of Contents
 
@@ -16,16 +15,15 @@ Looking for more information on Markov Chains? Try [Awesome Machine Learning](ht
 - [A history of funny Markov chains](#a-history-of-funny-markov-chains)
 - [Sober applications](#sober-applications)
 
-
 ## Web and Tech
 
 - [Headline Smasher](http://www.headlinesmasher.com/best/all) - Fake headlines created by smashing up real headlines.
 - [Subreddit Simulator](https://www.reddit.com/r/subredditsimulator) - The most confusing subreddit (often on the front page).
 - [Alternative Hacker News](https://news.ycombniator.com/) - Hacker News dataset eats itself.
-- [Phaker News](http://lou.wtf/phaker-news/) - Another spin on Hacker News.
+- [Phaker News](http://namuol.github.io/phaker-news/) - Another spin on Hacker News.
 - [Cybersauce Broadcasting Corporation](http://www.x11r5.com/radio/) - A computer generated and dictated podcast.
 - [Java! Real or Not?](http://java.metagno.me/) - Guess the Spring Framework class name.
-- [Your Swimsuit Jumped Over Its Own Weathercock, You Liar!](http://patchworkdollgames.com/yourswimsuit/) - A dating sim about the futility of dating sims.
+- [Your Swimsuit Jumped Over Its Own Weathercock, You Liar!](https://patchydollgames.itch.io/yourswimsuit) - A dating sim about the futility of dating sims.
 - [The Doom That Came to Puppet](http://thedoomthatcametopuppet.tumblr.com/) - Mutations on Puppet documentation and the assorted works of H. P. Lovecraft.
 - [King James Programming](http://kingjamesprogramming.tumblr.com/) - Combined King James Bible, Structure and Interpretation of Computer Programs, and some of Eric S. Raymond's writings.
 - [Git man page Generator](http://git-man-page-generator.lokaltog.net/) - Suspiciously believeable (but incorrect) Git documentation.
@@ -41,26 +39,21 @@ Looking for more information on Markov Chains? Try [Awesome Machine Learning](ht
 - [@twatterhose](https://twitter.com/twatterhose) - A mashup of the Twitter public timeline.
 - [@redditron](https://twitter.com/redditron) - Reddit comments.
 - [@markovmtg](https://twitter.com/markovmtg) - [Magic] Markov the Gathering.
-- [@nk_markov](https://twitter.com/nk_markov) - The glorious leader himself.
 - [@HNTitles](https://twitter.com/HNTitles) - HN Titles.
 - [@BeerSnobSays](https://twitter.com/BeerSnobSays) - Drunk tweeting nonsensical beer reviews.
 - [@icowid](https://twitter.com/icowid) - a markov bot trained on erowid trip reports and ICO whitepapers.
 - [@hipsterwid](https://twitter.com/hipsterwid) - An hipster bot trained on Erowid trip reports and Pitchfork's album reviews.
 
-
 ## Media
 
 - [Calvin and Markov](http://joshmillard.com/markov/calvin/) - Calvin and Hobbes strips reimagined.
 - [Garkov](http://joshmillard.com/garkov/) - Transcripts of old Garfield strips.
-- [Mulder's Big Adventure](http://muldersbigadventure.com/markov/) - Semi-coherent bits of random X-Files dialogue, based on community transcripts.
 - [The Big Markovski](http://joshmillard.com/markov/lebowski/) - The Big Lebowski.
 - [Jesus Markoving Christ](http://joshmillard.com/markov/christ/) - An incoherent savior for an incoherent age.
-- [Star Trek the Next Generation](http://joshmillard.com/markov/sttng/) - Previously, on Next Generation....
 - [XKCD](https://xkcd.com/210/) - 90's Flowchart.
 - [Markov Bible](https://web.archive.org/web/20081224025955/http://www.markovbible.com/) - The whole book (archive.org).
 - [Automatic Donald Trump](https://filiph.github.io/markov/) - Donald Trump's smart keyboard.
 - [Insta-Trump](http://trump.frost.works/) - create a mathematically generated Trump speech.
-
 
 ## Tools
 
@@ -76,13 +69,11 @@ Looking for more information on Markov Chains? Try [Awesome Machine Learning](ht
 - [Mark V. Shaney's Website](https://web.archive.org/web/19970418070034/http://softway.com.au/people/mvs/) - Mark V. Shaney's finest hours (archive.org).
 - [Fun With Markov Chains](http://www.eblong.com/zarf/markov/) - Featuring "Alice in Elsinore: The Alice books and Hamlet", and "The Revelation of St. Alice: The Alice books, and the books of Genesis and Revelation".
 
-
 ## Sober applications
 
 - [PageRank](https://en.wikipedia.org/wiki/PageRank?oldformat=true#Damping_factor) - Google is built on Markov Chains.
 - [Digital Music Programming](http://peabody.sapp.org/class/dmp2/lab/markov1/) - MIDI Markov music.
 - [A visual explanation of Markov chains](http://setosa.io/blog/2014/07/26/markov-chains/) - A useful guide to Markov chains by Victor Powell.
-
 
 ## License
 


### PR DESCRIPTION
Updated some deprecated links and removed some other where I did not find equivalents.

Note : "Alternative Hacker News" has a "potential security warning"